### PR TITLE
feat(ci): Update running examples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
               - 'geekorm-*/**'
               - 'examples/**'
               - 'tests/**'
+              - '.github/workflows/build.yml'
 
       - uses: dtolnay/rust-toolchain@nightly
         if: steps.changes.outputs.src == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
           cargo test -F all,hash-all --workspace
 
           # Run Examples Backend Features
-          cargo run -F all,libsql --example geekorm-example-turso-libsql
+          cargo run -F all,libsql --examples
 
   cli:
     name: CLI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,7 @@ jobs:
               - 'geekorm-*/**'
               - 'examples/**'
               - 'tests/**'
+              - '.github/workflows/build.yml'
 
       - uses: dtolnay/rust-toolchain@nightly
         if: steps.changes.outputs.src == 'true'
@@ -140,6 +141,7 @@ jobs:
               - 'geekorm-*/**'
               - 'examples/**'
               - 'tests/**'
+              - '.github/workflows/build.yml'
 
       - uses: dtolnay/rust-toolchain@nightly
         if: steps.changes.outputs.src == 'true'


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/build.yml` file. The change simplifies the command used to run examples of backend features.

The most important change is:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L122-R122): The command to run examples of backend features has been simplified from `cargo run -F all,libsql --example geekorm-example-turso-libsql` to `cargo run -F all,libsql --examples`. This change makes the command more general and easier to use, as it will now run all examples instead of a specific one.