### PR TITLE
feat(derive): Add better string parsing support

### DIFF
--- a/geekorm-derive/src/derive/column.rs
+++ b/geekorm-derive/src/derive/column.rs
@@ -179,6 +179,12 @@ impl ColumnDerive {
                         // If the column is unique, then it should be searchable by default
                         self.mode = Some(ColumnMode::Searchable { enabled: true });
                     }
+                    GeekAttributeKeys::OnValidate => {
+                        if let Some(GeekAttributeValue::Bool(validate)) = &attr.value {
+                            self.save = Some(validate.to_string());
+                            self.update = Some(validate.to_string());
+                        }
+                    }
                     GeekAttributeKeys::OnUpdate => {
                         if let Some(GeekAttributeValue::String(value)) = &attr.value {
                             self.update = Some(value.to_string());
@@ -339,6 +345,11 @@ impl ColumnDerive {
                     }
                     GeekAttributeKeys::HashAlgorithm => {
                         // Skip
+                    }
+                    GeekAttributeKeys::Key
+                    | GeekAttributeKeys::Disable
+                    | GeekAttributeKeys::Aliases => {
+                        // Skip (enum keys)
                     }
                 }
             } else {

--- a/geekorm-derive/src/lib.rs
+++ b/geekorm-derive/src/lib.rs
@@ -74,6 +74,7 @@ pub fn depricated_table_derive(input: TokenStream) -> TokenStream {
 /// enum Role {
 ///     Admin,
 ///     Moderator,
+///     #[geekorm(key = "UserAccounts")]
 ///     User,
 ///     #[default]
 ///     Guest,
@@ -92,8 +93,13 @@ pub fn depricated_table_derive(input: TokenStream) -> TokenStream {
 /// # assert_eq!(geekmasher.role, Role::Admin);
 /// # assert_eq!(Value::from(geekmasher.role), Value::Text("Admin".to_string()));
 /// # assert_eq!(Role::from(Value::Text("Admin".to_string())), Role::Admin);
+/// # assert_eq!(Role::from(Value::Text("UserAccounts".to_string())), Role::User);
+///
+/// let role = Role::from("UserAccounts");
+/// # assert_eq!(role, Role::User);
+/// # assert_eq!(role.to_string(), String::from("UserAccounts"));
 /// ```
-#[proc_macro_derive(Data)]
+#[proc_macro_derive(Data, attributes(geekorm))]
 pub fn data_derive(input: TokenStream) -> TokenStream {
     let ast: DeriveInput = parse_macro_input!(input as DeriveInput);
 

--- a/geekorm-derive/src/parsers.rs
+++ b/geekorm-derive/src/parsers.rs
@@ -8,7 +8,7 @@ use syn::{
 #[cfg(feature = "rand")]
 use geekorm_core::utils::generate_random_string;
 use geekorm_core::{Columns, Table};
-use values::{generate_from_value, generate_serde};
+use values::{generate_from_value, generate_serde, generate_strings};
 
 mod helpers;
 mod tablebuilder;
@@ -74,12 +74,20 @@ pub(crate) fn derive_parser(ast: &DeriveInput) -> Result<TokenStream, syn::Error
 pub(crate) fn enum_parser(ast: &DeriveInput) -> Result<TokenStream, syn::Error> {
     let name = &ast.ident;
 
+    let attributes = GeekAttribute::parse_all(&ast.attrs)?;
+
     match &ast.data {
         Data::Enum(DataEnum { variants, .. }) => {
             let mut tokens = TokenStream::new();
 
             tokens.extend(generate_from_value(name, variants, &ast.generics)?);
             tokens.extend(generate_serde(name, variants, &ast.generics)?);
+            tokens.extend(generate_strings(
+                name,
+                variants,
+                &ast.generics,
+                &attributes,
+            )?);
 
             Ok(tokens)
         }

--- a/geekorm-derive/src/parsers/tablebuilder.rs
+++ b/geekorm-derive/src/parsers/tablebuilder.rs
@@ -258,8 +258,6 @@ pub fn generate_backend(
             })?;
 
             auto_update.extend(quote! {
-                #[cfg(feature = "log")]
-                ::log::debug!("Auto updating field: '{}'", stringify!(#ident));
                 self.#ident = #auto;
             });
         }

--- a/geekorm-derive/src/parsers/values.rs
+++ b/geekorm-derive/src/parsers/values.rs
@@ -2,11 +2,14 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::spanned::Spanned;
 
-// impl From<&UserType> for geekorm::Value {
-//     fn from(value: &UserType) -> Self {
+use super::GeekAttribute;
+use crate::attr::GeekAttributeValue;
+
+// impl From<&UserRole> for geekorm::Value {
+//     fn from(value: &UserRole) -> Self {
 //         match value {
-//             UserType::Admin => geekorm::Value::Integer(0),
-//             UserType::User => geekorm::Value::Integer(1),
+//             UserRole::Admin => geekorm::Value::Integer(0),
+//             UserRole::User => geekorm::Value::Integer(1),
 //         }
 //     }
 // }
@@ -34,13 +37,33 @@ pub(crate) fn generate_from_value(
             ));
         }
 
+        let attributes = GeekAttribute::parse_all(&variant.attrs)?;
+
         let variant_ident = variant.ident.clone();
-        // TODO: Handle r# prefix better
-        let variant_string = variant_ident.to_string().replace("r#", "");
-        let variant_str = syn::LitStr::new(&variant_string, variant.span());
+
+        // Support `key` or `rename` attribute
+        let variant_str = if let Some(attr) = attributes
+            .iter()
+            .find(|&attr| attr.key == Some(crate::attr::GeekAttributeKeys::Key))
+        {
+            if let Some(GeekAttributeValue::String(value)) = &attr.value {
+                syn::LitStr::new(value, value.span())
+            } else if let Some(GeekAttributeValue::Int(value)) = &attr.value {
+                syn::LitStr::new(value.to_string().as_str(), value.span())
+            } else {
+                return Err(syn::Error::new(
+                    attr.span.span(),
+                    "Expected string or int value for `rename` attribute",
+                ));
+            }
+        } else {
+            // TODO: Handle r# prefix better
+            let variant_string = variant_ident.to_string().replace("r#", "");
+            syn::LitStr::new(&variant_string, variant.span())
+        };
 
         stream.extend(quote! {
-            #ident::#variant_ident => ::geekorm::Value::Text(String::from(#variant_str)),
+            #ident::#variant_ident => ::geekorm::Value::Text(value.to_string()),
         });
         from_value_stream.extend(quote! {
             ::geekorm::Value::Text(ref s) if s == #variant_str => #ident::#variant_ident,
@@ -49,7 +72,7 @@ pub(crate) fn generate_from_value(
 
     Ok(quote! {
         #[automatically_derived]
-        impl #impl_generics From<#ident #ty_generics> for geekorm::Value {
+        impl #impl_generics From<#ident #ty_generics> for ::geekorm::Value {
             fn from(value: #ident #ty_generics) -> Self {
                 match value {
                     #stream
@@ -59,7 +82,7 @@ pub(crate) fn generate_from_value(
         }
 
         #[automatically_derived]
-        impl #impl_generics From<&#ident #ty_generics> for geekorm::Value {
+        impl #impl_generics From<&#ident #ty_generics> for ::geekorm::Value {
             fn from(value: &#ident #ty_generics) -> Self {
                 match value {
                     #stream
@@ -69,12 +92,205 @@ pub(crate) fn generate_from_value(
         }
 
         #[automatically_derived]
-        impl #impl_generics From<geekorm::Value> for #ident #ty_generics {
+        impl #impl_generics From<::geekorm::Value> for #ident #ty_generics {
             fn from(value: geekorm::Value) -> Self {
                 match value {
                     #from_value_stream
                     _ => panic!("Unknown value"),
                 }
+            }
+        }
+    })
+}
+
+/// Generating ToString / Display implementations for the enum
+///
+/// ```rust
+/// # use geekorm::prelude::*;
+///
+/// # #[derive(Eq, PartialEq, Debug)]
+/// #[derive(Data, Default, Clone)]
+/// enum UserRole {
+///     #[geekorm(key = "Administrator")]
+///     Admin,
+///     #[geekorm(key = "AdminModerator")]
+///     Moderator,
+///     User,
+///     #[default]
+///     Guest,
+/// }
+///
+/// // The parsing is case-sensitive
+/// let user_type = UserRole::from("Administrator");
+/// # assert_eq!(user_type, UserRole::Admin);
+/// # assert_eq!(user_type.to_string(), "Administrator".to_string());
+///
+/// let moderator = UserRole::Moderator;
+/// # assert_eq!(moderator.to_string(), "AdminModerator".to_string());
+/// # let mod_value = geekorm::Value::Text(moderator.to_string());
+/// # assert_eq!(UserRole::from(mod_value), UserRole::Moderator);
+///
+/// let unknown = UserRole::from("unknown");
+/// // This will use the default value
+/// assert_eq!(unknown, UserRole::Guest);
+/// ```
+///
+/// ### Disabling Features
+///
+/// ```rust
+/// # use geekorm::prelude::*;
+///
+/// # #[derive(Eq, PartialEq, Debug)]
+/// #[derive(Data, Default, Clone)]
+/// #[geekorm(disable = "from_string")]     // Disable parsing from string
+/// enum UserRole {
+///     Admin,
+///     Moderator,
+///     User,
+///     #[default]
+///     Guest,
+/// }
+///
+/// // I can now implement the parsing myself
+/// impl From<&str> for UserRole {
+///     fn from(value: &str) -> Self {
+///         match value.to_string().to_lowercase().as_str() {
+///             "admin" | "root" => UserRole::Admin,
+///             "moderator" | "mod" => UserRole::Moderator,
+///             "user" => UserRole::User,
+///             "guest" => UserRole::Guest,
+///             // Defaults
+///             _ => UserRole::Guest,
+///         }
+///     }
+/// }
+///
+/// impl From<String> for UserRole {
+///     fn from(value: String) -> Self {
+///         Self::from(value.as_str())
+///     }
+/// }
+///
+/// // Try our parsing
+/// let user = UserRole::from("mod");
+/// # assert_eq!(user, UserRole::Moderator);
+/// # let user_string = UserRole::from(String::from("mod"));
+/// # assert_eq!(user_string, UserRole::Moderator);
+///
+/// ```
+pub(crate) fn generate_strings(
+    ident: &syn::Ident,
+    variants: &syn::punctuated::Punctuated<syn::Variant, syn::token::Comma>,
+    _generics: &syn::Generics,
+    attributes: &[GeekAttribute],
+) -> Result<TokenStream, syn::Error> {
+    let mut stream = TokenStream::new();
+    let mut str_to = TokenStream::new();
+
+    let disabled_from_strings = attributes.iter().any(|attr| {
+        attr.key == Some(crate::attr::GeekAttributeKeys::Disable)
+            && attr.value == Some(GeekAttributeValue::String("from_string".to_string()))
+    });
+
+    for variant in variants {
+        if !matches!(variant.fields, syn::Fields::Unit) {
+            return Err(syn::Error::new(
+                variant.span(),
+                "Only unit variants are supported",
+            ));
+        }
+        if variant.discriminant.is_some() {
+            return Err(syn::Error::new(
+                variant.span(),
+                "Discriminant values are not supported",
+            ));
+        }
+
+        let attrs = GeekAttribute::parse_all(&variant.attrs)?;
+
+        let variant_ident = variant.ident.clone();
+
+        // Support `key` or `rename` attribute
+        let variant_str = if let Some(attr) = attrs
+            .iter()
+            .find(|&attr| attr.key == Some(crate::attr::GeekAttributeKeys::Key))
+        {
+            if let Some(GeekAttributeValue::String(value)) = &attr.value {
+                syn::LitStr::new(value, value.span())
+            } else if let Some(GeekAttributeValue::Int(value)) = &attr.value {
+                syn::LitStr::new(value.to_string().as_str(), value.span())
+            } else {
+                return Err(syn::Error::new(
+                    attr.span.span(),
+                    "Expected string or int value for `rename` attribute",
+                ));
+            }
+        } else {
+            // TODO: Handle r# prefix better
+            let variant_string = variant_ident.to_string().replace("r#", "");
+            syn::LitStr::new(&variant_string, variant.span())
+        };
+
+        stream.extend(quote! {
+            #ident::#variant_ident => String::from(#variant_str),
+        });
+        if !disabled_from_strings {
+            str_to.extend(quote! {
+                #variant_str => #ident::#variant_ident,
+            });
+        }
+    }
+
+    let strings_tokens = if !disabled_from_strings {
+        quote! {
+            #[automatically_derived]
+            impl From<&str> for #ident
+            where
+                Self: Default
+            {
+                fn from(value: &str) -> Self {
+                    match value {
+                        #str_to
+                        _ => #ident::default(),
+                    }
+                }
+            }
+            #[automatically_derived]
+            impl From<String> for #ident
+            where
+                Self: Default
+            {
+                fn from(value: String) -> Self {
+                    Self::from(value.as_str())
+                }
+            }
+            #[automatically_derived]
+            impl From<&String> for #ident
+            where
+                Self: Default
+            {
+                fn from(value: &String) -> Self {
+                    Self::from(value.as_str())
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    Ok(quote! {
+        #strings_tokens
+
+        #[automatically_derived]
+        impl ::std::fmt::Display for #ident {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                write!(
+                    f,
+                    "{}",
+                    match self {
+                        #stream
+                    }
+                )
             }
         }
     })
@@ -90,6 +306,7 @@ pub(crate) fn generate_serde(
     let mut stream = TokenStream::new();
 
     stream.extend(quote! {
+        #[automatically_derived]
         impl ::serde::Serialize for #ident {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
@@ -126,12 +343,12 @@ pub(crate) fn generate_serde(
     }
 
     stream.extend(quote! {
+        #[automatically_derived]
         impl<'de> ::serde::Deserialize<'de> for #ident {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
                 D: ::serde::Deserializer<'de>,
             {
-
                 match String::deserialize(deserializer)?.as_str() {
                     #tokens
                     _ => Err(serde::de::Error::custom("Unknown user type")),


### PR DESCRIPTION
This pull request includes several enhancements and new features to the `geekorm-derive` library. The most important changes involve adding new attribute keys, improving parsing logic, and extending support for additional data types and functionalities.

Enhancements to attribute keys and parsing logic:

* [`geekorm-derive/src/attr.rs`](diffhunk://#diff-94dc70c862c23573319dc34c24566cf135e9011e273ed6d3ff509db5875208abL54-R57): Added new attribute keys (`Key`, `Aliases`, `OnValidate`, `Disable`) and updated the `GeekAttribute` struct to include a `Vec<String>` type. Improved parsing logic to handle these new keys and their respective values. [[1]](diffhunk://#diff-94dc70c862c23573319dc34c24566cf135e9011e273ed6d3ff509db5875208abL54-R57) [[2]](diffhunk://#diff-94dc70c862c23573319dc34c24566cf135e9011e273ed6d3ff509db5875208abR74-R75) [[3]](diffhunk://#diff-94dc70c862c23573319dc34c24566cf135e9011e273ed6d3ff509db5875208abR88-R89) [[4]](diffhunk://#diff-94dc70c862c23573319dc34c24566cf135e9011e273ed6d3ff509db5875208abR101-R115) [[5]](diffhunk://#diff-94dc70c862c23573319dc34c24566cf135e9011e273ed6d3ff509db5875208abL243-R261) [[6]](diffhunk://#diff-94dc70c862c23573319dc34c24566cf135e9011e273ed6d3ff509db5875208abR274-R277) [[7]](diffhunk://#diff-94dc70c862c23573319dc34c24566cf135e9011e273ed6d3ff509db5875208abR286)

Enhancements to `ColumnDerive`:

* [`geekorm-derive/src/derive/column.rs`](diffhunk://#diff-2248419f2d04b9298d37ba52500e29d57b3501a99af9ca2753b19fc6ecdf9fd0R182-R187): Added handling for the `OnValidate` attribute key to set the `save` and `update` properties accordingly. Updated logic to skip certain attribute keys (`Key`, `Disable`, `Aliases`). [[1]](diffhunk://#diff-2248419f2d04b9298d37ba52500e29d57b3501a99af9ca2753b19fc6ecdf9fd0R182-R187) [[2]](diffhunk://#diff-2248419f2d04b9298d37ba52500e29d57b3501a99af9ca2753b19fc6ecdf9fd0R349-R353)

Support for custom key attributes in enums:

* [`geekorm-derive/src/lib.rs`](diffhunk://#diff-6527b0cbc86a482ebeb7ca6c8497478ee3d0a9ab5531a8bf9dffb5f14be919ceR77): Demonstrated usage of the `key` attribute in documentation comments and updated the `data_derive` function to include `geekorm` attributes. [[1]](diffhunk://#diff-6527b0cbc86a482ebeb7ca6c8497478ee3d0a9ab5531a8bf9dffb5f14be919ceR77) [[2]](diffhunk://#diff-6527b0cbc86a482ebeb7ca6c8497478ee3d0a9ab5531a8bf9dffb5f14be919ceR96-R102)
* [`geekorm-derive/src/parsers.rs`](diffhunk://#diff-8ab57291be07e08804a5afe1ae94631c8668cc1e213aeef7c320e35498fcd1f8L11-R11): Added `generate_strings` function to support custom key attributes for enum variants, and integrated this function into the `enum_parser`. [[1]](diffhunk://#diff-8ab57291be07e08804a5afe1ae94631c8668cc1e213aeef7c320e35498fcd1f8L11-R11) [[2]](diffhunk://#diff-8ab57291be07e08804a5afe1ae94631c8668cc1e213aeef7c320e35498fcd1f8R77-R90)

Miscellaneous improvements:

* [`geekorm-derive/src/parsers/tablebuilder.rs`](diffhunk://#diff-8d02950b3212f9f2dbfa817a2598eacc117805dc3889c5daffe11d10db8a5133L261-L262): Removed unnecessary logging code in the `generate_backend` function.
* [`geekorm-derive/src/parsers/values.rs`](diffhunk://#diff-bbebc456a24bce18f5741fb051832137e465899218ed549e31cba6ad565250b7L5-R12): Added support for custom key attributes in the `generate_from_value` function and implemented `generate_strings` for `ToString` and `Display` traits. Improved `serde` serialization and deserialization implementations. [[1]](diffhunk://#diff-bbebc456a24bce18f5741fb051832137e465899218ed549e31cba6ad565250b7L5-R12) [[2]](diffhunk://#diff-bbebc456a24bce18f5741fb051832137e465899218ed549e31cba6ad565250b7R40-R66) [[3]](diffhunk://#diff-bbebc456a24bce18f5741fb051832137e465899218ed549e31cba6ad565250b7L52-R75) [[4]](diffhunk://#diff-bbebc456a24bce18f5741fb051832137e465899218ed549e31cba6ad565250b7L62-R85) [[5]](diffhunk://#diff-bbebc456a24bce18f5741fb051832137e465899218ed549e31cba6ad565250b7L72-R95) [[6]](diffhunk://#diff-bbebc456a24bce18f5741fb051832137e465899218ed549e31cba6ad565250b7R106-R298) [[7]](diffhunk://#diff-bbebc456a24bce18f5741fb051832137e465899218ed549e31cba6ad565250b7R309) [[8]](diffhunk://#diff-bbebc456a24bce18f5741fb051832137e465899218ed549e31cba6ad565250b7R346-L134)