### PR TITLE
Tokio Backends

### DIFF
--- a/.release.yml
+++ b/.release.yml
@@ -1,6 +1,6 @@
 name: "geekorm"
 repository: "42ByteLabs/geekorm"
-version: 0.8.2
+version: 0.8.3
 
 locations:
   - name: "Cargo - Workmembers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 license = "MIT"
 edition = "2021"
 rust-version = "1.74"
@@ -85,8 +85,8 @@ rusqlite = ["backends", "geekorm-derive/rusqlite", "geekorm-core/rusqlite"]
 # sqlite = ["backends", "geekorm-derive/sqlite", "geekorm-core/sqlite"]
 
 [dependencies]
-geekorm-core = { version = "^0.8.2", path = "geekorm-core" }
-geekorm-derive = { version = "^0.8.2", path = "geekorm-derive" }
+geekorm-core = { version = "^0.8.3", path = "geekorm-core" }
+geekorm-derive = { version = "^0.8.3", path = "geekorm-derive" }
 
 [dev-dependencies]
 geekorm = { path = ".", features = ["all", "semver", "tfa"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,5 +131,5 @@ required-features = ["all", "rusqlite"]
 [[example]]
 name = "rocket"
 path = "./examples/server-rocket/src/main.rs"
-required-features = ["all", "libsql"]
+required-features = ["all", "libsql", "backends-tokio"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ primary_key = ["geekorm-derive/primary_key"]
 
 # Backends for the ORM
 backends = ["search", "geekorm-core/backends", "geekorm-derive/backends"]
+backends-tokio = ["geekorm-core/backends-tokio"]
 search = ["geekorm-derive/search", "geekorm-core/search"]
 
 libsql = ["backends", "geekorm-derive/libsql", "geekorm-core/libsql"]

--- a/examples/server-rocket/Cargo.toml
+++ b/examples/server-rocket/Cargo.toml
@@ -9,10 +9,10 @@ categories.workspace = true
 authors.workspace = true
 
 [dependencies]
-geekorm = { path = "../../" }
+geekorm = { path = "../../", features = ["all", "libsql", "backends-tokio"] }
 anyhow = "1"
 
 rocket = { version = "^0.5", features = ["json"] }
-libsql = "^0.5"
+libsql = "^0.6"
 serde = "1"
 tokio = { version = "1", features = ["full"] }

--- a/geekorm-cli/Cargo.toml
+++ b/geekorm-cli/Cargo.toml
@@ -17,7 +17,7 @@ rust-version.workspace = true
 authors.workspace = true
 
 [dependencies]
-geekorm = { path = "../", version = "^0.8.1", features = ["utils"] }
+geekorm = { path = "../", version = "^0.8.3", features = ["utils"] }
 
 # CLI
 clap = { version = "4.0", features = ["derive", "env"] }

--- a/geekorm-core/Cargo.toml
+++ b/geekorm-core/Cargo.toml
@@ -46,9 +46,10 @@ hash-sha512 = ["dep:sha-crypt", "dep:rand_core"]
 
 # Backends
 backends = ["search"]
+backends-tokio = ["dep:tokio"]
 search = []
 
-libsql = ["backends", "dep:libsql"]
+libsql = ["backends", "dep:libsql", "dep:tokio"]
 rusqlite = ["backends", "dep:rusqlite", "dep:serde_rusqlite"]
 # sqlite = ["backends", "dep:sqlite"]
 
@@ -80,6 +81,8 @@ sha-crypt = { version = "^0.5", optional = true }
 libsql = { version = "^0.6", optional = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 serde_rusqlite = { version = "^0.36", optional = true }
+
+tokio = { version = "^1.40", features = ["full"], optional = true }
 
 [dev-dependencies]
 geekorm = { path = ".." }

--- a/geekorm-derive/Cargo.toml
+++ b/geekorm-derive/Cargo.toml
@@ -52,7 +52,7 @@ rusqlite = ["backends", "geekorm-core/rusqlite"]
 proc-macro = true
 
 [dependencies]
-geekorm-core = { path = "../geekorm-core", version = "^0.8.2" }
+geekorm-core = { path = "../geekorm-core", version = "^0.8.3" }
 
 thiserror = "^2.0"
 # macro magic


### PR DESCRIPTION
This pull request includes several changes to update dependencies, add new backend support, and modify the `server-rocket` example to use asynchronous connections. The most important changes include updating versions, adding support for `backends-tokio`, and refactoring the `server-rocket` example to use `tokio::sync::Mutex`.

### Version Updates:
* Updated the version of the `geekorm` package from `0.8.2` to `0.8.3` in `.release.yml` and `Cargo.toml` files. [[1]](diffhunk://#diff-d4d7cd04ba0a6d75051dff03d7466433e762738ada5263a4b2a87f8ed23c16e4L3-R3) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L11-R11) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R80-R89) [[4]](diffhunk://#diff-696866b630cf8008d2632b94a53e36d45da2cbba55dc163a3152efbb48ba8643L20-R20) [[5]](diffhunk://#diff-faf07a6fa97f44e2a09102531b098e0ab475eef69008e529ea74d167c073b50cL55-R55)

### Backend Support:
* Added support for `backends-tokio` in `Cargo.toml` files and updated dependencies accordingly. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R80-R89) [[2]](diffhunk://#diff-5087458903144e2312a5ea4976541c36c5651efc103a46759d271fef73ec4dedR49-R52) [[3]](diffhunk://#diff-5087458903144e2312a5ea4976541c36c5651efc103a46759d271fef73ec4dedR85-R86)

### Server-Rocket Example Refactor:
* Refactored the `server-rocket` example to use `tokio::sync::Mutex` for asynchronous database connections, including changes in `main.rs` and `Cargo.toml`. [[1]](diffhunk://#diff-518cb35d1d242b6dcc15feb380c5848773fb088917c8027d682b6984b1878273L6-R11) [[2]](diffhunk://#diff-518cb35d1d242b6dcc15feb380c5848773fb088917c8027d682b6984b1878273L21-R27) [[3]](diffhunk://#diff-518cb35d1d242b6dcc15feb380c5848773fb088917c8027d682b6984b1878273L64-R67) [[4]](diffhunk://#diff-188a74eb139c19b3c416f9c4ffd4762c64cf9e4da52cd088651a00633ce5858dL12-R16)

### Geekorm-Core Changes:
* Modified `geekorm-core` to use `tokio::sync::Mutex` when the `backends-tokio` feature is enabled, including changes in `libsql.rs`. [[1]](diffhunk://#diff-1ea78e235d945f67e0b4b8b8918ac9802fdd6e7677d8041d7d55e4091cdd1601R38-R47) [[2]](diffhunk://#diff-1ea78e235d945f67e0b4b8b8918ac9802fdd6e7677d8041d7d55e4091cdd1601L376-R391) [[3]](diffhunk://#diff-1ea78e235d945f67e0b4b8b8918ac9802fdd6e7677d8041d7d55e4091cdd1601L407-R409) [[4]](diffhunk://#diff-1ea78e235d945f67e0b4b8b8918ac9802fdd6e7677d8041d7d55e4091cdd1601L428-R430) [[5]](diffhunk://#diff-1ea78e235d945f67e0b4b8b8918ac9802fdd6e7677d8041d7d55e4091cdd1601L450-R452) [[6]](diffhunk://#diff-1ea78e235d945f67e0b4b8b8918ac9802fdd6e7677d8041d7d55e4091cdd1601L471-R473)