### PR TITLE
feat(backends): Update Wait timeout

### DIFF
--- a/geekorm-core/src/backends/libsql/mutex.rs
+++ b/geekorm-core/src/backends/libsql/mutex.rs
@@ -8,6 +8,7 @@ use tokio::sync::Mutex;
 
 use crate::{GeekConnection, QueryBuilderTrait, TableBuilder};
 
+const WAIT: std::time::Duration = std::time::Duration::from_nanos(100);
 const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 impl<C> GeekConnection for Arc<Mutex<C>>
@@ -26,7 +27,7 @@ where
             match connection.try_lock() {
                 Ok(conn) => return C::create_table::<T>(&conn).await,
                 Err(_) => {
-                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    std::thread::sleep(WAIT);
                 }
             }
         }
@@ -45,7 +46,7 @@ where
             match connection.try_lock() {
                 Ok(conn) => return C::row_count(&conn, query).await,
                 Err(_) => {
-                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    std::thread::sleep(WAIT);
                 }
             }
         }
@@ -67,7 +68,7 @@ where
             match connection.try_lock() {
                 Ok(conn) => return C::query::<T>(&conn, query).await,
                 Err(_) => {
-                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    std::thread::sleep(WAIT);
                 }
             }
         }
@@ -90,7 +91,7 @@ where
             match connection.try_lock() {
                 Ok(conn) => return C::query_first::<T>(&conn, query).await,
                 Err(_) => {
-                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    std::thread::sleep(WAIT);
                 }
             }
         }
@@ -109,7 +110,7 @@ where
             match connection.try_lock() {
                 Ok(conn) => return C::execute(&conn, query).await,
                 Err(_) => {
-                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    std::thread::sleep(WAIT);
                 }
             }
         }


### PR DESCRIPTION
This pull request includes changes to the `geekorm-core/src/backends/libsql/mutex.rs` file to improve code consistency and maintainability. The main change involves replacing hard-coded sleep durations with a constant.

Code consistency improvements:

* Added a constant `WAIT` with a duration of 100 nanoseconds to replace hard-coded sleep durations.
* Replaced `std::thread::sleep(std::time::Duration::from_millis(10))` with `std::thread::sleep(WAIT)` in multiple locations to use the new constant. [[1]](diffhunk://#diff-6215c746bad5814d08213b0675a4616eff36ec0030359208ccb70e3a3317391fL29-R30) [[2]](diffhunk://#diff-6215c746bad5814d08213b0675a4616eff36ec0030359208ccb70e3a3317391fL48-R49) [[3]](diffhunk://#diff-6215c746bad5814d08213b0675a4616eff36ec0030359208ccb70e3a3317391fL70-R71) [[4]](diffhunk://#diff-6215c746bad5814d08213b0675a4616eff36ec0030359208ccb70e3a3317391fL93-R94) [[5]](diffhunk://#diff-6215c746bad5814d08213b0675a4616eff36ec0030359208ccb70e3a3317391fL112-R113)