### PR TITLE
SQL Transaction Minor Improvements

### DIFF
--- a/geekorm-core/src/backends/connect/backend.rs
+++ b/geekorm-core/src/backends/connect/backend.rs
@@ -54,7 +54,7 @@ impl GeekConnection for Connection<'_> {
 
     async fn transactions(
         connection: &mut Self::Connection,
-        queries: &Vec<geekorm_sql::Query>,
+        queries: &[geekorm_sql::Query],
     ) -> Result<(), crate::Error> {
         connection
             .query_count

--- a/geekorm-core/src/backends/connect/mod.rs
+++ b/geekorm-core/src/backends/connect/mod.rs
@@ -157,9 +157,12 @@ impl Display for Connection<'_> {
 
 impl Drop for Connection<'_> {
     fn drop(&mut self) {
-        // On drop, we put the connection back into the pool
-        // TODO: Can we remove this clone?
-        self.pool.insert_backend(self.backend.clone());
+        // Transactions are not added back to the pool
+        if !matches!(self.backend, Backend::Transactions { .. }) {
+            // On drop, we put the connection back into the pool
+            // TODO: Can we remove this clone?
+            self.pool.insert_backend(self.backend.clone());
+        }
     }
 }
 

--- a/geekorm-core/src/backends/mod.rs
+++ b/geekorm-core/src/backends/mod.rs
@@ -388,7 +388,7 @@ pub trait GeekConnection {
     #[allow(async_fn_in_trait, unused_variables)]
     async fn transactions(
         connection: &mut Self::Connection,
-        queries: &Vec<geekorm_sql::Query>,
+        queries: &[geekorm_sql::Query],
     ) -> Result<(), crate::Error> {
         Err(crate::Error::NotImplemented)
     }

--- a/geekorm-core/src/backends/rusqlite.rs
+++ b/geekorm-core/src/backends/rusqlite.rs
@@ -215,7 +215,7 @@ impl GeekConnection for rusqlite::Connection {
         for query in queries {
             let params = values_to_rusqlite(query.values().clone());
 
-            tx.execute(&query.sql(), params)?;
+            tx.execute(query.as_sql(), params)?;
         }
 
         tx.commit()?;

--- a/geekorm-core/src/backends/rusqlite.rs
+++ b/geekorm-core/src/backends/rusqlite.rs
@@ -99,9 +99,9 @@ impl GeekConnection for rusqlite::Connection {
             .map_err(|e| crate::Error::RuSQLiteError(e.to_string()))?;
 
         let params = if !query.parameters.values().is_empty() {
-            values_to_rusqlite(query.parameters)
+            values_to_rusqlite(&query.parameters)
         } else {
-            values_to_rusqlite(query.values)
+            values_to_rusqlite(&query.values)
         };
         #[cfg(feature = "log")]
         {
@@ -138,9 +138,9 @@ impl GeekConnection for rusqlite::Connection {
             .map_err(|e| crate::Error::RuSQLiteError(e.to_string()))?;
 
         let params = if !query.parameters.values().is_empty() {
-            values_to_rusqlite(query.parameters)
+            values_to_rusqlite(&query.parameters)
         } else {
-            values_to_rusqlite(query.values)
+            values_to_rusqlite(&query.values)
         };
         #[cfg(feature = "log")]
         {
@@ -172,9 +172,9 @@ impl GeekConnection for rusqlite::Connection {
             .map_err(|e| crate::Error::RuSQLiteError(e.to_string()))?;
 
         let params = if !query.parameters.values().is_empty() {
-            values_to_rusqlite(query.parameters)
+            values_to_rusqlite(&query.parameters)
         } else {
-            values_to_rusqlite(query.values)
+            values_to_rusqlite(&query.values)
         };
         #[cfg(feature = "log")]
         {
@@ -204,7 +204,7 @@ impl GeekConnection for rusqlite::Connection {
 
     async fn transactions(
         connection: &mut Self::Connection,
-        queries: &Vec<geekorm_sql::Query>,
+        queries: &[geekorm_sql::Query],
     ) -> std::prelude::v1::Result<(), crate::Error> {
         #[cfg(feature = "log")]
         {
@@ -213,7 +213,7 @@ impl GeekConnection for rusqlite::Connection {
         let tx = connection.transaction()?;
 
         for query in queries {
-            let params = values_to_rusqlite(query.values().clone());
+            let params = values_to_rusqlite(query.values());
 
             tx.execute(query.as_sql(), params)?;
         }
@@ -230,7 +230,7 @@ impl GeekConnection for rusqlite::Connection {
             .prepare(query.to_str())
             .map_err(|e| crate::Error::RuSQLiteError(e.to_string()))?;
 
-        let params = values_to_rusqlite(query.parameters);
+        let params = values_to_rusqlite(&query.parameters);
 
         //let params = rusqlite::params_from_iter(query.parameters);
         let mut res = statement
@@ -248,7 +248,7 @@ impl GeekConnection for rusqlite::Connection {
 
 /// Value -> DatabaseValue -> Rusqlite Value
 #[inline]
-fn values_to_rusqlite(values: Values) -> ParamsFromIter<Vec<DatabaseValue>> {
+fn values_to_rusqlite(values: &Values) -> ParamsFromIter<Vec<DatabaseValue>> {
     rusqlite::params_from_iter(
         values
             .values()

--- a/geekorm-core/src/backends/transactions.rs
+++ b/geekorm-core/src/backends/transactions.rs
@@ -21,8 +21,7 @@ impl TransactionConnector {
     }
     /// Push a query to the transaction connector
     pub fn push(&self, query: Query) {
-        self.queries.lock().unwrap().push(query);
-        println!("QUERIES :: {}", self.queries.lock().unwrap().len())
+        self.queries.lock().unwrap().push(query)
     }
 }
 

--- a/geekorm-sql/src/query/batch.rs
+++ b/geekorm-sql/src/query/batch.rs
@@ -30,6 +30,11 @@ impl BatchQueries {
         self.queries.len()
     }
 
+    /// Are there any queries
+    pub fn is_empty(&self) -> bool {
+        self.queries.is_empty()
+    }
+
     /// Load a SQL file
     pub fn load(path: impl Into<PathBuf>) -> Result<Self, Error> {
         let path = path.into();

--- a/geekorm-sql/src/query/batch.rs
+++ b/geekorm-sql/src/query/batch.rs
@@ -76,7 +76,7 @@ impl BatchQueries {
     }
 
     /// Gets all the internal queries
-    pub fn queries(&self) -> &Vec<Query> {
+    pub fn queries(&self) -> &[Query] {
         &self.queries
     }
 }

--- a/geekorm-sql/src/query/mod.rs
+++ b/geekorm-sql/src/query/mod.rs
@@ -61,6 +61,11 @@ impl Query {
         self.query.clone()
     }
 
+    /// Get the SQL query as a string slice
+    pub fn as_sql(&self) -> &str {
+        &self.query
+    }
+
     /// Get Query Type
     pub fn query_type(&self) -> &QueryType {
         &self.query_type


### PR DESCRIPTION
- Improve the connection drop so that Transaction Connector are not added back to the pool
- Move from `Vec<Query>` to `&[Query` to prevent over clone-ing
- Add `as_sql` which returns a string slice `&str` to stop over clone-ing