### PR TITLE
Named Parameters support

### DIFF
--- a/geekorm-core/src/backends/connect/backend.rs
+++ b/geekorm-core/src/backends/connect/backend.rs
@@ -54,7 +54,7 @@ impl GeekConnection for Connection<'_> {
 
     async fn transactions(
         connection: &mut Self::Connection,
-        queries: &Vec<geekorm_sql::Query>,
+        queries: &[geekorm_sql::Query],
     ) -> Result<(), crate::Error> {
         connection
             .query_count

--- a/geekorm-core/src/backends/connect/mod.rs
+++ b/geekorm-core/src/backends/connect/mod.rs
@@ -157,9 +157,12 @@ impl Display for Connection<'_> {
 
 impl Drop for Connection<'_> {
     fn drop(&mut self) {
-        // On drop, we put the connection back into the pool
-        // TODO: Can we remove this clone?
-        self.pool.insert_backend(self.backend.clone());
+        // Transactions are not added back to the pool
+        if !matches!(self.backend, Backend::Transactions { .. }) {
+            // On drop, we put the connection back into the pool
+            // TODO: Can we remove this clone?
+            self.pool.insert_backend(self.backend.clone());
+        }
     }
 }
 

--- a/geekorm-core/src/backends/mod.rs
+++ b/geekorm-core/src/backends/mod.rs
@@ -388,7 +388,7 @@ pub trait GeekConnection {
     #[allow(async_fn_in_trait, unused_variables)]
     async fn transactions(
         connection: &mut Self::Connection,
-        queries: &Vec<geekorm_sql::Query>,
+        queries: &[geekorm_sql::Query],
     ) -> Result<(), crate::Error> {
         Err(crate::Error::NotImplemented)
     }

--- a/geekorm-core/src/backends/rusqlite.rs
+++ b/geekorm-core/src/backends/rusqlite.rs
@@ -215,7 +215,7 @@ impl GeekConnection for rusqlite::Connection {
         for query in queries {
             let params = values_to_rusqlite(query.values().clone());
 
-            tx.execute(&query.sql(), params)?;
+            tx.execute(query.as_sql(), params)?;
         }
 
         tx.commit()?;

--- a/geekorm-core/src/backends/rusqlite.rs
+++ b/geekorm-core/src/backends/rusqlite.rs
@@ -99,9 +99,9 @@ impl GeekConnection for rusqlite::Connection {
             .map_err(|e| crate::Error::RuSQLiteError(e.to_string()))?;
 
         let params = if !query.parameters.values().is_empty() {
-            values_to_rusqlite(query.parameters)
+            values_to_rusqlite(&query.parameters)
         } else {
-            values_to_rusqlite(query.values)
+            values_to_rusqlite(&query.values)
         };
         #[cfg(feature = "log")]
         {
@@ -138,9 +138,9 @@ impl GeekConnection for rusqlite::Connection {
             .map_err(|e| crate::Error::RuSQLiteError(e.to_string()))?;
 
         let params = if !query.parameters.values().is_empty() {
-            values_to_rusqlite(query.parameters)
+            values_to_rusqlite(&query.parameters)
         } else {
-            values_to_rusqlite(query.values)
+            values_to_rusqlite(&query.values)
         };
         #[cfg(feature = "log")]
         {
@@ -172,9 +172,9 @@ impl GeekConnection for rusqlite::Connection {
             .map_err(|e| crate::Error::RuSQLiteError(e.to_string()))?;
 
         let params = if !query.parameters.values().is_empty() {
-            values_to_rusqlite(query.parameters)
+            values_to_rusqlite(&query.parameters)
         } else {
-            values_to_rusqlite(query.values)
+            values_to_rusqlite(&query.values)
         };
         #[cfg(feature = "log")]
         {
@@ -204,7 +204,7 @@ impl GeekConnection for rusqlite::Connection {
 
     async fn transactions(
         connection: &mut Self::Connection,
-        queries: &Vec<geekorm_sql::Query>,
+        queries: &[geekorm_sql::Query],
     ) -> std::prelude::v1::Result<(), crate::Error> {
         #[cfg(feature = "log")]
         {
@@ -213,7 +213,7 @@ impl GeekConnection for rusqlite::Connection {
         let tx = connection.transaction()?;
 
         for query in queries {
-            let params = values_to_rusqlite(query.values().clone());
+            let params = values_to_rusqlite(query.values());
 
             tx.execute(query.as_sql(), params)?;
         }
@@ -230,7 +230,7 @@ impl GeekConnection for rusqlite::Connection {
             .prepare(query.to_str())
             .map_err(|e| crate::Error::RuSQLiteError(e.to_string()))?;
 
-        let params = values_to_rusqlite(query.parameters);
+        let params = values_to_rusqlite(&query.parameters);
 
         //let params = rusqlite::params_from_iter(query.parameters);
         let mut res = statement
@@ -248,7 +248,7 @@ impl GeekConnection for rusqlite::Connection {
 
 /// Value -> DatabaseValue -> Rusqlite Value
 #[inline]
-fn values_to_rusqlite(values: Values) -> ParamsFromIter<Vec<DatabaseValue>> {
+fn values_to_rusqlite(values: &Values) -> ParamsFromIter<Vec<DatabaseValue>> {
     rusqlite::params_from_iter(
         values
             .values()

--- a/geekorm-core/src/backends/transactions.rs
+++ b/geekorm-core/src/backends/transactions.rs
@@ -21,8 +21,7 @@ impl TransactionConnector {
     }
     /// Push a query to the transaction connector
     pub fn push(&self, query: Query) {
-        self.queries.lock().unwrap().push(query);
-        println!("QUERIES :: {}", self.queries.lock().unwrap().len())
+        self.queries.lock().unwrap().push(query)
     }
 }
 

--- a/geekorm-sql/src/builder/conditions.rs
+++ b/geekorm-sql/src/builder/conditions.rs
@@ -1,6 +1,7 @@
 //! # Query Conditions
 
 use super::QueryBuilder;
+use crate::values::values::ValueBindingMode;
 use crate::{Error, ToSql};
 
 /// Query Condition (EQ, NE, etc.)
@@ -105,6 +106,10 @@ impl WhereClause {
 
 impl ToSql for WhereClause {
     fn sql(&self) -> String {
+        self.to_sql(&QueryBuilder::default()).unwrap()
+    }
+
+    fn to_sql(&self, query: &QueryBuilder) -> Result<String, Error> {
         let mut stream = String::new();
         if !self.is_empty() {
             // Add the where clause to the SQL string
@@ -114,7 +119,16 @@ impl ToSql for WhereClause {
                 stream.push_str(column);
                 stream.push(' ');
                 stream.push_str(&qcondition.sql());
-                stream.push_str(" ?");
+
+                match query.values.binding_mode {
+                    ValueBindingMode::Placeholder => {
+                        stream.push_str(" ?");
+                    }
+                    ValueBindingMode::Named => {
+                        stream.push_str(&format!(" :{}", column));
+                    }
+                    ValueBindingMode::Numeric => todo!("WhereClause -> ValueBindingMode::Numeric"),
+                }
 
                 if let Some(next_condition) = wcondition {
                     stream.push_str(&format!(" {} ", next_condition.sql()));
@@ -122,13 +136,13 @@ impl ToSql for WhereClause {
             }
         }
 
-        stream
+        Ok(stream)
     }
 
     fn to_sql_stream(&self, stream: &mut String, query: &QueryBuilder) -> Result<(), Error> {
         if !query.where_clause.is_empty() {
             stream.push(' ');
-            stream.push_str(&self.sql());
+            stream.push_str(&self.to_sql(query)?);
         }
         Ok(())
     }
@@ -164,6 +178,18 @@ mod tests {
 
     #[test]
     fn test_where_clause_or() {
+        let mut where_clause = WhereClause::default();
+        where_clause.push("id".to_string(), QueryCondition::Eq);
+        where_clause.push_condition(WhereCondition::Or).unwrap();
+        where_clause.push("name".to_string(), QueryCondition::Like);
+
+        let query = where_clause.sql();
+
+        assert_eq!(query, "WHERE id = ? OR name LIKE ?");
+    }
+
+    #[test]
+    fn test_where_named_values() {
         let mut where_clause = WhereClause::default();
         where_clause.push("id".to_string(), QueryCondition::Eq);
         where_clause.push_condition(WhereCondition::Or).unwrap();

--- a/geekorm-sql/src/builder/conditions.rs
+++ b/geekorm-sql/src/builder/conditions.rs
@@ -71,6 +71,11 @@ pub struct WhereClause {
 }
 
 impl WhereClause {
+    /// New WHERE clause
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// If the where clause is empty
     pub fn is_empty(&self) -> bool {
         self.conditions.is_empty()
@@ -121,6 +126,7 @@ impl ToSql for WhereClause {
                 stream.push_str(&qcondition.sql());
                 stream.push(' ');
 
+                // SECURITY: Parameterise all the values being passed in
                 match query.values.binding_mode {
                     ValueBindingMode::Placeholder => {
                         stream.push('?');

--- a/geekorm-sql/src/builder/conditions.rs
+++ b/geekorm-sql/src/builder/conditions.rs
@@ -119,15 +119,22 @@ impl ToSql for WhereClause {
                 stream.push_str(column);
                 stream.push(' ');
                 stream.push_str(&qcondition.sql());
+                stream.push(' ');
 
                 match query.values.binding_mode {
                     ValueBindingMode::Placeholder => {
-                        stream.push_str(" ?");
+                        stream.push('?');
                     }
                     ValueBindingMode::Named => {
-                        stream.push_str(&format!(" :{}", column));
+                        stream.push_str(&format!(":{}", column));
                     }
-                    ValueBindingMode::Numeric => todo!("WhereClause -> ValueBindingMode::Numeric"),
+                    ValueBindingMode::Numeric => {
+                        let index = query
+                            .values
+                            .get_index(column.as_str())
+                            .expect("Failed to fetch value index");
+                        stream.push_str(&format!("?{}", index));
+                    }
                 }
 
                 if let Some(next_condition) = wcondition {
@@ -153,6 +160,7 @@ mod tests {
     use super::*;
     use crate::ToSql;
     use crate::builder::QueryBuilder;
+    use crate::builder::tests::*;
 
     #[test]
     fn test_where_clause_eq() {
@@ -189,14 +197,39 @@ mod tests {
     }
 
     #[test]
-    fn test_where_named_values() {
-        let mut where_clause = WhereClause::default();
-        where_clause.push("id".to_string(), QueryCondition::Eq);
-        where_clause.push_condition(WhereCondition::Or).unwrap();
-        where_clause.push("name".to_string(), QueryCondition::Like);
+    fn test_where_named_query() {
+        let table = table_users();
+        let query = QueryBuilder::select()
+            .table(&table)
+            .set_value_mode(ValueBindingMode::Named)
+            .where_eq("id", 1)
+            .or()
+            .where_like("username", "geek")
+            .build()
+            .unwrap();
 
-        let query = where_clause.sql();
+        assert_eq!(query.values.len(), 2);
+        assert_eq!(
+            query.as_sql(),
+            "SELECT id, username, email, roles, profile FROM Users WHERE id = :id OR username LIKE :username;"
+        );
+    }
 
-        assert_eq!(query, "WHERE id = ? OR name LIKE ?");
+    #[test]
+    fn test_where_numeric_query() {
+        let table = table_users();
+        let query = QueryBuilder::select()
+            .table(&table)
+            .set_value_mode(ValueBindingMode::Numeric)
+            .where_like("username", "geek")
+            .where_eq("id", 1)
+            .build()
+            .unwrap();
+
+        assert_eq!(query.values.len(), 2);
+        assert_eq!(
+            query.as_sql(),
+            "SELECT id, username, email, roles, profile FROM Users WHERE username LIKE ?1 AND id = ?2;"
+        );
     }
 }

--- a/geekorm-sql/src/builder/mod.rs
+++ b/geekorm-sql/src/builder/mod.rs
@@ -23,6 +23,7 @@ use crate::{
     Column, Error, Query, QueryBackend, ToSql, Value, Values,
     builder::{pagination::Page, queries::transaction::TransactionQuery},
     query::BatchQueries,
+    values::values::ValueBindingMode,
 };
 use columns::Columns;
 
@@ -204,6 +205,12 @@ impl<'a> QueryBuilder<'a> {
     /// Add a value to the list of values for parameterized queries
     pub fn add_value(&mut self, column: &str, value: impl Into<Value>) -> &mut Self {
         self.values.push(column.to_string(), value.into());
+        self
+    }
+
+    /// Set the value binding mode
+    pub(crate) fn set_value_mode(&mut self, mode: ValueBindingMode) -> &mut Self {
+        self.values.binding_mode = mode;
         self
     }
 

--- a/geekorm-sql/src/builder/mod.rs
+++ b/geekorm-sql/src/builder/mod.rs
@@ -78,7 +78,10 @@ pub struct QueryBuilder<'a> {
     /// Page
     pub(crate) page: Option<Page>,
 
+    /// Data Values for the query
     pub(crate) values: Values,
+    /// If the values should be ordered or named
+    pub(crate) named_values: bool,
 
     /// For Alter queries
     pub(crate) alter: Option<AlterQuery>,

--- a/geekorm-sql/src/builder/mod.rs
+++ b/geekorm-sql/src/builder/mod.rs
@@ -152,10 +152,13 @@ impl<'a> QueryBuilder<'a> {
         }
     }
 
-    /// Build an update query
+    /// Build an UPDATE query.
+    ///
+    /// Update queries use named parametered for the query.
     pub fn update() -> Self {
         Self {
             query_type: QueryType::Update,
+            values: Values::new_with_binding_mode(ValueBindingMode::Named),
             ..Default::default()
         }
     }

--- a/geekorm-sql/src/builder/queries/insert.rs
+++ b/geekorm-sql/src/builder/queries/insert.rs
@@ -19,7 +19,6 @@ impl QueryType {
 
             let mut columns: Vec<String> = Vec::new();
             let mut values: Vec<String> = Vec::new();
-            let mut parameters = Values::new();
 
             for nvalue in query.values.values() {
                 let column = table.find_column(nvalue.name()).unwrap();
@@ -33,25 +32,8 @@ impl QueryType {
 
                 columns.push(column_name.clone());
 
-                // Add to Values
-                match nvalue.value() {
-                    Value::Identifier(_) | Value::Text(_) | Value::Json(_) => {
-                        // Security: String values should never be directly inserted into the query
-                        // This is to prevent SQL injection attacks
-                        values.push(String::from("?"));
-                        parameters.push(column_name, nvalue.value().clone());
-                    }
-                    Value::Blob(value) => {
-                        // Security: Blods should never be directly inserted into the query
-                        values.push(String::from("?"));
-                        parameters.push(column_name, value.clone());
-                    }
-                    Value::Integer(value) => values.push(value.to_string()),
-                    Value::Real(value) => values.push(value.to_string()),
-                    Value::Boolean(value) => values.push(value.to_string()),
-                    Value::Datetime(value) => values.push(value.to_string()),
-                    Value::Null => values.push("NULL".to_string()),
-                }
+                let value_param = nvalue.to_sql(query).unwrap();
+                values.push(value_param);
             }
 
             full_query.push_str(" (");

--- a/geekorm-sql/src/builder/queries/select.rs
+++ b/geekorm-sql/src/builder/queries/select.rs
@@ -94,6 +94,23 @@ mod tests {
     }
 
     #[test]
+    fn sqlite_select_where_pk() {
+        let table = table_images();
+        let query = QueryBuilder::select()
+            .table(&table)
+            .set_value_mode(crate::values::values::ValueBindingMode::Named)
+            .where_eq("id", 42)
+            .build()
+            .unwrap();
+
+        assert_eq!(query.values.len(), 1);
+        assert_eq!(
+            query.query,
+            "SELECT id, title, url FROM Images WHERE id = :id;"
+        );
+    }
+
+    #[test]
     fn sqlite_order_clause() {
         let table = table_images();
         let query = QueryBuilder::select()

--- a/geekorm-sql/src/builder/queries/transaction.rs
+++ b/geekorm-sql/src/builder/queries/transaction.rs
@@ -124,7 +124,7 @@ mod tests {
         assert_eq!(query.values.len(), 2);
         assert_eq!(
             sql,
-            "BEGIN TRANSACTION;\n\nUPDATE Users SET username = ? WHERE id = 1;\n\nCOMMIT;"
+            "BEGIN TRANSACTION;\n\nUPDATE Users SET username = ? WHERE id = ?;\n\nCOMMIT;"
         );
     }
 }

--- a/geekorm-sql/src/builder/queries/transaction.rs
+++ b/geekorm-sql/src/builder/queries/transaction.rs
@@ -124,7 +124,7 @@ mod tests {
         assert_eq!(query.values.len(), 2);
         assert_eq!(
             sql,
-            "BEGIN TRANSACTION;\n\nUPDATE Users SET username = ? WHERE id = ?;\n\nCOMMIT;"
+            "BEGIN TRANSACTION;\n\nUPDATE Users SET username = :username WHERE id = :id;\n\nCOMMIT;"
         );
     }
 }

--- a/geekorm-sql/src/builder/queries/update.rs
+++ b/geekorm-sql/src/builder/queries/update.rs
@@ -135,24 +135,7 @@ mod tests {
             .build()
             .unwrap();
 
-        assert_eq!(
-            query.query,
-            "UPDATE Test SET name = ?, email = ? WHERE id = ?;"
-        );
-    }
-
-    #[test]
-    fn sqlite_update_named_query() {
-        let table = table();
-        let query = QueryBuilder::update()
-            .table(&table)
-            .set_value_mode(crate::values::values::ValueBindingMode::Named)
-            .add_value("id", "1")
-            .add_value("name", "bob")
-            .add_value("email", "bob@example.com")
-            .build()
-            .unwrap();
-
+        // Named parameters by default
         assert_eq!(
             query.query,
             "UPDATE Test SET name = :name, email = :email WHERE id = :id;"
@@ -175,7 +158,7 @@ mod tests {
 
         assert_eq!(
             query.query,
-            "UPDATE OR ROLLBACK Test SET name = ?, email = ? WHERE id = ?;"
+            "UPDATE OR ROLLBACK Test SET name = :name, email = :email WHERE id = :id;"
         );
     }
 }

--- a/geekorm-sql/src/builder/queries/update.rs
+++ b/geekorm-sql/src/builder/queries/update.rs
@@ -3,7 +3,9 @@
 //!
 
 use crate::backends::SqliteBackendOptions;
+use crate::builder::WhereClause;
 use crate::builder::table::TableExpr;
+use crate::values::values::ValueBindingMode;
 use crate::{QueryBuilder, QueryType, ToSql, Value, Values};
 
 impl QueryType {
@@ -37,24 +39,31 @@ impl QueryType {
                 }
 
                 // Add to Values
-                match nvalue.value() {
-                    Value::Identifier(_) | Value::Text(_) | Value::Blob(_) | Value::Json(_) => {
-                        // Security: String values should never be directly inserted into the query
-                        // This is to prevent SQL injection attacks
-                        columns.push(format!("{} = ?", column_name));
-                        parameters.push(column_name, nvalue.value().clone());
+                if matches!(nvalue.value(), Value::Null) {
+                    columns.push(format!("{} = NULL", column_name));
+                } else {
+                    // SECURITY: String values should never be directly inserted into the query
+                    let mut value_param = format!("{} = ", column_name);
+                    // This is to prevent SQL injection attacks
+                    // SECURITY: Parameterise all the values being passed in
+                    match query.values.binding_mode {
+                        ValueBindingMode::Placeholder => {
+                            value_param.push('?');
+                        }
+                        ValueBindingMode::Named => {
+                            value_param.push_str(&format!(":{}", column_name));
+                        }
+                        ValueBindingMode::Numeric => {
+                            let index = query
+                                .values
+                                .get_index(column_name.as_str())
+                                .expect("Failed to fetch value index");
+                            value_param.push_str(&format!("?{}", index));
+                        }
                     }
-                    Value::Integer(value) => {
-                        columns.push(format!("{} = {}", column_name, value));
-                    }
-                    Value::Real(value) => {
-                        columns.push(format!("{} = {}", column_name, value));
-                    }
-                    Value::Datetime(value) => {
-                        columns.push(format!("{} = {}", column_name, value));
-                    }
-                    Value::Boolean(value) => columns.push(format!("{} = {}", column_name, value)),
-                    Value::Null => columns.push(format!("{} = NULL", column_name)),
+
+                    columns.push(value_param);
+                    parameters.push(column_name, nvalue.value().clone());
                 }
             }
 
@@ -65,8 +74,17 @@ impl QueryType {
             // TODO(geekmasher): We only support updating by primary key
             if let Some(primary_key) = table.get_primary_key() {
                 let primary_key_name = primary_key.name.clone();
-                let primary_key = query.values.get(&primary_key_name).unwrap();
-                let where_clause = format!(" WHERE {} = {}", primary_key_name, primary_key);
+
+                // SECURITY: primary keys need to parameters
+                let mut pk_where = WhereClause::new();
+                pk_where.push(primary_key_name, crate::QueryCondition::Eq);
+
+                let where_clause = pk_where
+                    .to_sql(query)
+                    .expect("Update Query - PK building error");
+                debug_assert_ne!(where_clause.len(), 0);
+
+                full_query.push(' ');
                 full_query.push_str(&where_clause);
             }
         }
@@ -119,7 +137,25 @@ mod tests {
 
         assert_eq!(
             query.query,
-            "UPDATE Test SET name = ?, email = ? WHERE id = 1;"
+            "UPDATE Test SET name = ?, email = ? WHERE id = ?;"
+        );
+    }
+
+    #[test]
+    fn sqlite_update_named_query() {
+        let table = table();
+        let query = QueryBuilder::update()
+            .table(&table)
+            .set_value_mode(crate::values::values::ValueBindingMode::Named)
+            .add_value("id", "1")
+            .add_value("name", "bob")
+            .add_value("email", "bob@example.com")
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            query.query,
+            "UPDATE Test SET name = :name, email = :email WHERE id = :id;"
         );
     }
 
@@ -139,7 +175,7 @@ mod tests {
 
         assert_eq!(
             query.query,
-            "UPDATE OR ROLLBACK Test SET name = ?, email = ? WHERE id = 1;"
+            "UPDATE OR ROLLBACK Test SET name = ?, email = ? WHERE id = ?;"
         );
     }
 }

--- a/geekorm-sql/src/query/batch.rs
+++ b/geekorm-sql/src/query/batch.rs
@@ -30,6 +30,11 @@ impl BatchQueries {
         self.queries.len()
     }
 
+    /// Are there any queries
+    pub fn is_empty(&self) -> bool {
+        self.queries.is_empty()
+    }
+
     /// Load a SQL file
     pub fn load(path: impl Into<PathBuf>) -> Result<Self, Error> {
         let path = path.into();

--- a/geekorm-sql/src/query/batch.rs
+++ b/geekorm-sql/src/query/batch.rs
@@ -76,7 +76,7 @@ impl BatchQueries {
     }
 
     /// Gets all the internal queries
-    pub fn queries(&self) -> &Vec<Query> {
+    pub fn queries(&self) -> &[Query] {
         &self.queries
     }
 }

--- a/geekorm-sql/src/query/mod.rs
+++ b/geekorm-sql/src/query/mod.rs
@@ -61,6 +61,11 @@ impl Query {
         self.query.clone()
     }
 
+    /// Get the SQL query as a string slice
+    pub fn as_sql(&self) -> &str {
+        &self.query
+    }
+
     /// Get Query Type
     pub fn query_type(&self) -> &QueryType {
         &self.query_type

--- a/geekorm-sql/src/values/values.rs
+++ b/geekorm-sql/src/values/values.rs
@@ -59,8 +59,9 @@ impl Values {
     }
 
     /// Push a value to the list of values
-    pub fn push(&mut self, column: String, value: impl Into<Value>) {
-        self.values.push(NamedValue::new(column, value.into()))
+    pub fn push(&mut self, column: impl Into<String>, value: impl Into<Value>) {
+        self.values
+            .push(NamedValue::new(column.into(), value.into()))
     }
 
     /// Get a value by index from the list of values
@@ -88,6 +89,16 @@ impl Values {
     pub fn values(&self) -> &Vec<NamedValue> {
         &self.values
     }
+
+    /// Gets the index of the column (starts from 1)
+    pub fn get_index(&self, column: &str) -> Option<usize> {
+        for (index, value) in self.values.iter().enumerate() {
+            if value.name == column {
+                return Some(index + 1);
+            }
+        }
+        None
+    }
 }
 
 impl IntoIterator for Values {
@@ -106,5 +117,25 @@ impl IntoIterator for Values {
 impl From<NamedValue> for Value {
     fn from(value: NamedValue) -> Self {
         value.value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_values_get_index() {
+        let mut values = Values::new();
+        values.push("id", Value::Integer(1));
+        values.push("username", Value::Text("GeekMasher".to_string()));
+        values.push("first_name", Value::Text("mathew".to_string()));
+        values.push("age", Value::Integer(42)); // I'm not :( 
+
+        assert_eq!(values.len(), 4);
+        assert_eq!(values.get_index("id"), Some(1));
+        assert_eq!(values.get_index("username"), Some(2));
+        assert_eq!(values.get_index("first_name"), Some(3));
+        assert_eq!(values.get_index("age"), Some(4));
     }
 }

--- a/geekorm-sql/src/values/values.rs
+++ b/geekorm-sql/src/values/values.rs
@@ -2,6 +2,7 @@
 //!
 //! A collection of values to be used in SQL queries.
 use super::value::Value;
+use crate::ToSql;
 
 /// The different options on how to bind values
 ///
@@ -40,6 +41,32 @@ impl NamedValue {
     /// Get Value
     pub fn value(&self) -> &Value {
         &self.value
+    }
+}
+
+impl ToSql for NamedValue {
+    fn to_sql(&self, query: &crate::QueryBuilder) -> Result<String, crate::prelude::Error> {
+        let mut stream = String::new();
+
+        // This is to prevent SQL injection attacks
+        // SECURITY: Parameterise all the values being passed in
+        match query.values.binding_mode {
+            ValueBindingMode::Placeholder => {
+                stream.push('?');
+            }
+            ValueBindingMode::Named => {
+                stream.push_str(&format!(":{}", self.name()));
+            }
+            ValueBindingMode::Numeric => {
+                let index = query
+                    .values
+                    .get_index(self.name())
+                    .expect("Failed to fetch value index");
+                stream.push_str(&format!("?{}", index));
+            }
+        }
+
+        Ok(stream)
     }
 }
 
@@ -122,6 +149,8 @@ impl From<NamedValue> for Value {
 
 #[cfg(test)]
 mod tests {
+    use crate::QueryBuilder;
+
     use super::*;
 
     #[test]
@@ -137,5 +166,23 @@ mod tests {
         assert_eq!(values.get_index("username"), Some(2));
         assert_eq!(values.get_index("first_name"), Some(3));
         assert_eq!(values.get_index("age"), Some(4));
+    }
+
+    #[test]
+    fn sqlite_named_value() {
+        let mut builder = QueryBuilder::update();
+        builder.set_value_mode(ValueBindingMode::Named);
+
+        let named = NamedValue::new("id", Value::Integer(1));
+        let query = named.to_sql(&builder).unwrap();
+        assert_eq!(query.as_str(), ":id");
+
+        let named = NamedValue::new("username", Value::Text("geekmasher".to_string()));
+        let query = named.to_sql(&builder).unwrap();
+        assert_eq!(query.as_str(), ":username");
+
+        let named = NamedValue::new("id", Value::Identifier(1));
+        let query = named.to_sql(&builder).unwrap();
+        assert_eq!(query.as_str(), ":id");
     }
 }

--- a/geekorm-sql/src/values/values.rs
+++ b/geekorm-sql/src/values/values.rs
@@ -3,6 +3,20 @@
 //! A collection of values to be used in SQL queries.
 use super::value::Value;
 
+/// The different options on how to bind values
+///
+/// https://sqlite.org/c3ref/bind_blob.html
+#[derive(Debug, Default, Clone, PartialEq)]
+pub enum ValueBindingMode {
+    /// This is using the standard `?`
+    #[default]
+    Placeholder,
+    /// Named value `:VVV`
+    Named,
+    /// Numeric like `:NNN`
+    Numeric,
+}
+
 /// Named Value
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct NamedValue {
@@ -34,12 +48,14 @@ impl NamedValue {
 pub struct Values {
     /// List of values
     pub(crate) values: Vec<NamedValue>,
+    /// Binding mode that should be used for these particular values
+    pub(crate) binding_mode: ValueBindingMode,
 }
 
 impl Values {
     /// Create a new instance of Values
     pub fn new() -> Self {
-        Values { values: Vec::new() }
+        Values::default()
     }
 
     /// Push a value to the list of values

--- a/geekorm-sql/src/values/values.rs
+++ b/geekorm-sql/src/values/values.rs
@@ -85,6 +85,14 @@ impl Values {
         Values::default()
     }
 
+    /// Create a new instance of Values but with a binding mode
+    pub fn new_with_binding_mode(mode: ValueBindingMode) -> Self {
+        Values {
+            values: Vec::new(),
+            binding_mode: mode,
+        }
+    }
+
     /// Push a value to the list of values
     pub fn push(&mut self, column: impl Into<String>, value: impl Into<Value>) {
         self.values


### PR DESCRIPTION
- Support for #280 
- UPDATE queries use named parameters by default now
  - This is because of ordering issues that could come up